### PR TITLE
Add currentTime to audio ontimeupdate event

### DIFF
--- a/src/event-to-object.js
+++ b/src/event-to-object.js
@@ -78,6 +78,9 @@ const eventCategoryTransforms = {
     pseudoElement: event.pseudoElement,
     elapsedTime: event.elapsedTime,
   }),
+  audio: (event) => ({
+    currentTime: event.currentTime,
+  }),
 };
 
 const eventTypeCategories = {
@@ -122,6 +125,7 @@ const eventTypeCategories = {
   wheel: ["wheel"],
   animation: ["animationstart", "animationend", "animationiteration"],
   transition: ["transitionend"],
+  audio: ["ontimeupdate"],
 };
 
 const eventTransforms = {};


### PR DESCRIPTION
I want to display the `currentTime` alongside an audio element (and I also just wanted to play around with IDOM). 

From the now defunct gitter:
> Ryan Morshead @rmorshea Mar 06 19:44
@scottire there is no built-in way to query attributes of client-side elements. All data communicated from the client to the server is done in the form of events. With that said, would it be sufficient for onTimeUpdate events to send back the value of currentTime? This would require an addition to IDOM's client-side event serializer that should be pretty straightforward. Let me know if you'd like any help in making that contribution. If you don't have the time, create an issue, and I'll try to get to it when I can.

The first commit is largely to get the ball rolling on this so I can add any changes / tests / docs.

One question so I can test this, what's your typical workflow for developing this IDOM javascript dependency? 
Do you locally clone this and have another local `idom` repo and then `npm install ../../../../../idom-client-react` from within `idom/src/idom/client/app`? 
